### PR TITLE
Use /tmp instead of /test/tmp for running tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,3 @@
 
 # But make sure to ignore these regardless:
 WAS *
-/test/tmp

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,6 @@
 		"package-lock.json": true,
 		"node_modules": true,
 		"*/**/node_modules": false,
-		"test/tmp": true
+		"tmp": true
 	}
 }

--- a/test/class.spec.js
+++ b/test/class.spec.js
@@ -10,7 +10,7 @@ const {copyConfig, compileFixture} = require("./shared");
 let app;
 let server;
 const port = 8888;
-const outputFolder = join(__dirname, `tmp/web/dist`);
+const outputFolder = join(process.cwd(), `tmp/web/dist`);
 
 function sleep(duration) {
 	return new Promise(resolve => {

--- a/test/class.spec.js
+++ b/test/class.spec.js
@@ -5,12 +5,12 @@ const {strictEqual, deepStrictEqual} = require("assert");
 const {join} = require("path");
 const express = require("express");
 const puppeteer = require("puppeteer");
-const {copyConfig, compileFixture} = require("./shared");
+const {tmpFolder, copyConfig, compileFixture} = require("./shared");
 
 let app;
 let server;
 const port = 8888;
-const outputFolder = join(process.cwd(), `tmp/web/dist`);
+const distFolder = join(tmpFolder, "web/dist");
 
 function sleep(duration) {
 	return new Promise(resolve => {
@@ -67,7 +67,7 @@ before("Setup", function() {
 	return new Promise(resolve => {
 		copyConfig("web");
 		app = express();
-		app.use(express.static(outputFolder));
+		app.use(express.static(distFolder));
 		server = app.listen(port, () => {
 			resolve();
 		});

--- a/test/lint.spec.js
+++ b/test/lint.spec.js
@@ -3,9 +3,11 @@
 /* eslint-disable global-require */
 "use strict";
 const {deepStrictEqual} = require("assert");
+const {join} = require("path");
 const Ajv = require("ajv");
 const draft04 = require("ajv/lib/refs/json-schema-draft-04.json");
 const tsconfigSchema = require("./tsconfig.schema.json");
+const {packagesFolder} = require("./shared");
 
 function assertSchema(tsconfig) {
 	const linter = new Ajv({meta: false, schemaId: "id"});
@@ -17,11 +19,11 @@ function assertSchema(tsconfig) {
 
 describe("Lint", function() {
 	it("Node", function() {
-		const tsconfig = require("../packages/tsconfig-node/tsconfig.json");
+		const tsconfig = require(join(packagesFolder, "tsconfig-node/tsconfig.json"));
 		assertSchema(tsconfig);
 	});
 	it("Web", function() {
-		const tsconfig = require("../packages/tsconfig-web/tsconfig.json");
+		const tsconfig = require(join(packagesFolder, "tsconfig-web/tsconfig.json"));
 		assertSchema(tsconfig);
 	});
 });

--- a/test/node.spec.js
+++ b/test/node.spec.js
@@ -4,8 +4,9 @@
 const {join} = require("path");
 const {deepStrictEqual} = require("assert");
 const {copySync} = require("fs-extra");
-const {copyConfig, compileFixture, execCommand} = require("./shared");
-const tmpFolder = join(process.cwd(), "tmp/node");
+const {tmpFolder, copyConfig, compileFixture, execCommand} = require("./shared");
+const tmpSubfolder = join(tmpFolder, "node");
+
 
 function testFixture(
 	{
@@ -40,7 +41,7 @@ function testFixture(
 			if (typeof copyFiles === "object" && copyFiles !== null) {
 				for (const relativeSrc in copyFiles) {
 					const relativeDest = copyFiles[relativeSrc];
-					copySync(join(tmpFolder, relativeSrc), join(tmpFolder, relativeDest));
+					copySync(join(tmpSubfolder, relativeSrc), join(tmpSubfolder, relativeDest));
 				}
 			}
 

--- a/test/node.spec.js
+++ b/test/node.spec.js
@@ -5,7 +5,7 @@ const {join} = require("path");
 const {deepStrictEqual} = require("assert");
 const {copySync} = require("fs-extra");
 const {copyConfig, compileFixture, execCommand} = require("./shared");
-const tmpFolder = join(__dirname, "tmp/node");
+const tmpFolder = join(process.cwd(), "tmp/node");
 
 function testFixture(
 	{

--- a/test/setup.js
+++ b/test/setup.js
@@ -4,7 +4,7 @@ const {join} = require("path");
 const {writeFileSync} = require("fs");
 const {removeSync, mkdirpSync} = require("fs-extra");
 const {devDependencies} = require("../package.json");
-const tmpFolder = join(__dirname, `tmp`);
+const tmpFolder = join(process.cwd(), `tmp`);
 const {execCommand} = require("./shared");
 
 async function setupFolder(id, extraPackages) {

--- a/test/shared.js
+++ b/test/shared.js
@@ -30,7 +30,7 @@ function execCommand(command, folder) {
 
 function copyConfig(configId = "node") {
 	const fromPackageFolder = join(__dirname, `../packages/tsconfig-${configId}`);
-	const toPackageFolder = join(__dirname, `tmp/${configId}/node_modules/@wildpeaks/tsconfig-${configId}`);
+	const toPackageFolder = join(process.cwd(), `tmp/${configId}/node_modules/@wildpeaks/tsconfig-${configId}`);
 	try {
 		removeSync(toPackageFolder);
 	} catch (e) {}
@@ -48,7 +48,7 @@ async function getFiles(folder) {
 
 async function compileFixture(configId, fixtureId, command) {
 	const fromFixtureFolder = join(__dirname, fixtureId);
-	const toTmpFolder = join(__dirname, `tmp/${configId}`);
+	const toTmpFolder = join(process.cwd(), `tmp/${configId}`);
 
 	try {
 		removeSync(join(toTmpFolder, "bin"));

--- a/test/shared.js
+++ b/test/shared.js
@@ -6,6 +6,8 @@ const {writeFileSync} = require("fs");
 const {join, relative} = require("path");
 const {copySync, removeSync} = require("fs-extra");
 const rreaddir = require("recursive-readdir");
+const packagesFolder = join(__dirname, "../packages");
+const tmpFolder = join(__dirname, "../tmp");
 
 function execCommand(command, folder) {
 	return new Promise(resolve => {
@@ -29,8 +31,8 @@ function execCommand(command, folder) {
 }
 
 function copyConfig(configId = "node") {
-	const fromPackageFolder = join(__dirname, `../packages/tsconfig-${configId}`);
-	const toPackageFolder = join(process.cwd(), `tmp/${configId}/node_modules/@wildpeaks/tsconfig-${configId}`);
+	const fromPackageFolder = join(packagesFolder, `tsconfig-${configId}`);
+	const toPackageFolder = join(tmpFolder, `${configId}/node_modules/@wildpeaks/tsconfig-${configId}`);
 	try {
 		removeSync(toPackageFolder);
 	} catch (e) {}
@@ -48,77 +50,81 @@ async function getFiles(folder) {
 
 async function compileFixture(configId, fixtureId, command) {
 	const fromFixtureFolder = join(__dirname, fixtureId);
-	const toTmpFolder = join(process.cwd(), `tmp/${configId}`);
+	const toTmpSubfolder = join(tmpFolder, configId);
 
 	try {
-		removeSync(join(toTmpFolder, "bin"));
+		removeSync(join(toTmpSubfolder, "bin"));
 	} catch (e) {}
 	try {
-		removeSync(join(toTmpFolder, "src"));
+		removeSync(join(toTmpSubfolder, "src"));
 	} catch (e) {}
 	try {
-		removeSync(join(toTmpFolder, "custom-path"));
+		removeSync(join(toTmpSubfolder, "custom-path"));
 	} catch (e) {}
 	try {
-		removeSync(join(toTmpFolder, "node_modules/fake1"));
+		removeSync(join(toTmpSubfolder, "node_modules/fake1"));
 	} catch (e) {}
 	try {
-		removeSync(join(toTmpFolder, "node_modules/fake2"));
+		removeSync(join(toTmpSubfolder, "node_modules/fake2"));
 	} catch (e) {}
 	try {
-		removeSync(join(toTmpFolder, "lib"));
+		removeSync(join(toTmpSubfolder, "lib"));
 	} catch (e) {}
 	try {
-		removeSync(join(toTmpFolder, "dist"));
+		removeSync(join(toTmpSubfolder, "dist"));
 	} catch (e) {}
 	try {
-		removeSync(join(toTmpFolder, "webpack.config.js"));
+		removeSync(join(toTmpSubfolder, "webpack.config.js"));
 	} catch (e) {}
 	try {
-		removeSync(join(toTmpFolder, "tsconfig.json"));
+		removeSync(join(toTmpSubfolder, "tsconfig.json"));
 	} catch (e) {}
 
 	try {
-		copySync(join(fromFixtureFolder, "bin"), join(toTmpFolder, "bin"));
+		copySync(join(fromFixtureFolder, "bin"), join(toTmpSubfolder, "bin"));
 	} catch (e) {}
 	try {
-		copySync(join(fromFixtureFolder, "src"), join(toTmpFolder, "src"));
+		copySync(join(fromFixtureFolder, "src"), join(toTmpSubfolder, "src"));
 	} catch (e) {}
 	try {
-		copySync(join(fromFixtureFolder, "custom-path"), join(toTmpFolder, "custom-path"));
+		copySync(join(fromFixtureFolder, "custom-path"), join(toTmpSubfolder, "custom-path"));
 	} catch (e) {}
 	try {
-		copySync(join(fromFixtureFolder, "node_modules/fake1"), join(toTmpFolder, "node_modules/fake1"));
+		copySync(join(fromFixtureFolder, "node_modules/fake1"), join(toTmpSubfolder, "node_modules/fake1"));
 	} catch (e) {}
 	try {
-		copySync(join(fromFixtureFolder, "node_modules/fake2"), join(toTmpFolder, "node_modules/fake2"));
+		copySync(join(fromFixtureFolder, "node_modules/fake2"), join(toTmpSubfolder, "node_modules/fake2"));
 	} catch (e) {}
 	try {
-		copySync(join(fromFixtureFolder, "webpack.config.js"), join(toTmpFolder, "webpack.config.js"));
+		copySync(join(fromFixtureFolder, "webpack.config.js"), join(toTmpSubfolder, "webpack.config.js"));
 	} catch (e) {}
 	try {
-		copySync(join(fromFixtureFolder, "tsconfig.json"), join(toTmpFolder, "tsconfig.json"));
+		copySync(join(fromFixtureFolder, "tsconfig.json"), join(toTmpSubfolder, "tsconfig.json"));
 	} catch (e) {}
 	writeFileSync(
-		join(toTmpFolder, "package.json"),
+		join(toTmpSubfolder, "package.json"),
 		JSON.stringify({private: true, scripts: {build: command}}),
 		"utf8"
 	);
 
-	const filesBefore = await getFiles(toTmpFolder);
-	const {output, errors} = await execCommand("npm run build", toTmpFolder);
-	const filesAfter = await getFiles(toTmpFolder);
+	const filesBefore = await getFiles(toTmpSubfolder);
+	const {output, errors} = await execCommand("npm run build", toTmpSubfolder);
+	const filesAfter = await getFiles(toTmpSubfolder);
 
 	return {
 		output,
 		errors,
-		folder: toTmpFolder,
+		folder: toTmpSubfolder,
 		filesBefore,
 		filesAfter
 	};
 }
 
-module.exports.execCommand = execCommand;
-module.exports.getFiles = getFiles;
-module.exports.copyConfig = copyConfig;
-module.exports.compileFixture = compileFixture;
+module.exports = {
+	tmpFolder,
+	packagesFolder,
+	execCommand,
+	getFiles,
+	copyConfig,
+	compileFixture
+};

--- a/test/web.spec.js
+++ b/test/web.spec.js
@@ -5,12 +5,12 @@ const {strictEqual, deepStrictEqual} = require("assert");
 const {join} = require("path");
 const express = require("express");
 const puppeteer = require("puppeteer");
-const {copyConfig, compileFixture} = require("./shared");
+const {tmpFolder, copyConfig, compileFixture} = require("./shared");
 
 let app;
 let server;
 const port = 8888;
-const outputFolder = join(__dirname, `tmp/web/dist`);
+const distFolder = join(tmpFolder, `web/dist`);
 
 function sleep(duration) {
 	return new Promise(resolve => {
@@ -81,7 +81,7 @@ before("Setup", function() {
 	return new Promise(resolve => {
 		copyConfig("web");
 		app = express();
-		app.use(express.static(outputFolder));
+		app.use(express.static(distFolder));
 		server = app.listen(port, () => {
 			resolve();
 		});


### PR DESCRIPTION
Because /test is whitelisted in gitignore, therefore it needs a matching exclusion for /test/tmp to avoid storing temporary files in Git. Also /tmp makes slightly smaller filepaths.