### PR TITLE
Package updates

### DIFF
--- a/packages/tsconfig-node/package.json
+++ b/packages/tsconfig-node/package.json
@@ -19,6 +19,6 @@
     "tsconfig.json"
   ],
   "dependencies": {
-    "@types/node": "13.9.3"
+    "@types/node": "12.12.31"
   }
 }

--- a/packages/tsconfig-node/package.json
+++ b/packages/tsconfig-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wildpeaks/tsconfig-node",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Base tsconfig for Node projects",
   "author": "Cecile Muller",
   "license": "MIT",

--- a/packages/tsconfig-web/package.json
+++ b/packages/tsconfig-web/package.json
@@ -21,6 +21,6 @@
     "types.d.ts"
   ],
   "dependencies": {
-    "@types/node": "13.9.3"
+    "@types/node": "12.12.31"
   }
 }

--- a/packages/tsconfig-web/package.json
+++ b/packages/tsconfig-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wildpeaks/tsconfig-web",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Base tsconfig for Webpack projects",
   "author": "Cecile Muller",
   "license": "MIT",


### PR DESCRIPTION
I looks like `@types/node` accidentally pushed the wrong version on "latest" (all tests still passed with it though), hence this new version despite the previous one was barely a few hours ago.